### PR TITLE
Added error handling for cases when Windows API calls fail explicitly

### DIFF
--- a/agent/eni/iphelperwrapper/iphelper_windows_test.go
+++ b/agent/eni/iphelperwrapper/iphelper_windows_test.go
@@ -37,6 +37,12 @@ var (
 		return uintptr(0), uintptr(0), nil
 	}
 
+	// Dummy function which is representative of system call (NotifyIPInterfaceChange)
+	// Invokation of this function returns Windows error 87 (The parameter is incorrect.)
+	dummyFuncNotifyIPInterfaceChangeWithError = func(...uintptr) (uintptr, uintptr, error) {
+		return uintptr(87), uintptr(0), nil
+	}
+
 	// Dummy function which is representative of system call (CancelMibChangeNotify2)
 	dummyFuncCancelMibChangeNotify2 = func(...uintptr) (uintptr, uintptr, error) {
 		return uintptr(0), uintptr(0), nil
@@ -52,6 +58,19 @@ var (
 		InterfaceIndex: 9,
 	}
 )
+
+func TestStartMonitorWithErrorWhileCallingWindowsAPI(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// Overriding the windows API call with a dummy call
+	funcNotifyIPInterfaceChange = dummyFuncNotifyIPInterfaceChangeWithError
+	funcCancelMibChangeNotify2 = dummyFuncCancelMibChangeNotify2
+	infMonitor := NewMonitor()
+
+	err := infMonitor.StartMonitor(notificationChannel)
+	assert.Error(t, err)
+}
 
 // Test for StartMonitor. This is a success test case in which initial notification is sent immediately
 func TestStartMonitorInitialNotificationImmediately(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
